### PR TITLE
Fix installation instructions for CMakeLists.txt setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,18 @@ conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'main'
       src/*.c
       ${CMAKE_SOURCE_DIR}/lib/picoruby/mrbgems/*/ports/rp2040/*.c
       ${CMAKE_SOURCE_DIR}/lib/picoruby/mrbgems/*/ports/common/*.c
-   +  ${CMAKE_SOURCE_DIR}/lib/picoruby/build/repos/*/*/ports/rp2040/*.c
+   +  ${CMAKE_SOURCE_DIR}/lib/picoruby/build/repos/${MRUBY_CONFIG}/*/ports/rp2040/*.c
     )
+   ```
+
+   ```diff
+    pico_generate_pio_header(${PROJECT_NAME}
+      ${CMAKE_SOURCE_DIR}/lib/picoruby/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922_pio.pio
+    )
+
+   +pico_generate_pio_header(${PROJECT_NAME}
+   +  ${CMAKE_SOURCE_DIR}/lib/picoruby/build/repos/${MRUBY_CONFIG}/picoruby-ws2812/ports/rp2040/ws2812.pio
+   +)
    ```
 
 3. Clean and rebuild:


### PR DESCRIPTION
## Summary
- Use `${MRUBY_CONFIG}` instead of wildcard for repos path
- Add missing `pico_generate_pio_header` directive for ws2812.pio

## Why
When both picoruby-pico and picoruby-pico2 are built, using wildcard `*` 
could match both directories. Using `${MRUBY_CONFIG}` ensures the correct 
config-specific path is referenced.