### PR TITLE
Add configurable color order support (GRB/RGB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ led.close
 ### Constructor
 
 ```ruby
-WS2812.new(pin:, num:)
+WS2812.new(pin:, num:, order: :grb)
 ```
 
 - `pin`: GPIO pin number (Integer)
 - `num`: Number of LEDs (Integer)
+- `order`: Color order (Symbol, optional). `:grb` (default, standard WS2812) or `:rgb`
 
 ### Methods
 

--- a/include/ws2812.h
+++ b/include/ws2812.h
@@ -17,8 +17,12 @@ void WS2812_put_pixel(uint8_t g, uint8_t r, uint8_t b);
 /* Send multiple pixels from array (GRB order, deprecated) */
 void WS2812_write(const uint8_t *data, int len);
 
-/* Show pixels with brightness scaling (RGB order input) */
-void WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness);
+/* Color order constants */
+#define WS2812_ORDER_GRB 0
+#define WS2812_ORDER_RGB 1
+
+/* Show pixels with brightness scaling (RGB order input, reordered by color_order) */
+void WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness, uint8_t color_order);
 
 /* Deinitialize WS2812 driver */
 void WS2812_deinit(void);

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -7,10 +7,11 @@ end
 class WS2812
   attr_reader :brightness
 
-  def initialize(pin:, num:)
+  def initialize(pin:, num:, order: :grb)
     @num_leds = num
     @brightness = 100
     @buffer = Array.new(num * 3, 0)
+    @order = order
 
     # ESP32: use RMT directly, RP2040/RP2350: use C bindings
     begin
@@ -63,12 +64,16 @@ class WS2812
         r = (@buffer[i * 3] * scale).to_i
         g = (@buffer[i * 3 + 1] * scale).to_i
         b = (@buffer[i * 3 + 2] * scale).to_i
-        bytes << g << r << b  # GRB order
+        if @order == :rgb
+          bytes << r << g << b
+        else
+          bytes << g << r << b
+        end
       end
       @rmt.write(bytes)
     else
       # RP2040/RP2350: use optimized C implementation
-      _show(@buffer, @brightness)
+      _show(@buffer, @brightness, @order == :rgb ? 1 : 0)
     end
   end
 

--- a/ports/rp2040/ws2812.c
+++ b/ports/rp2040/ws2812.c
@@ -76,7 +76,7 @@ WS2812_write(const uint8_t *data, int len)
 }
 
 void
-WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness)
+WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness, uint8_t color_order)
 {
     if (!ws2812_config.initialized) return;
 
@@ -86,8 +86,12 @@ WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness)
         uint8_t g = (rgb_data[i * 3 + 1] * brightness) / 100;
         uint8_t b = (rgb_data[i * 3 + 2] * brightness) / 100;
 
-        /* GRB order for WS2812 */
-        uint32_t pixel = ((uint32_t)g << 16) | ((uint32_t)r << 8) | (uint32_t)b;
+        uint32_t pixel;
+        if (color_order == WS2812_ORDER_RGB) {
+            pixel = ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+        } else {  /* GRB (default) */
+            pixel = ((uint32_t)g << 16) | ((uint32_t)r << 8) | (uint32_t)b;
+        }
         ws2812_put_pixel(ws2812_config.pio, ws2812_config.sm, pixel);
     }
 

--- a/sig/WS2812.rbs
+++ b/sig/WS2812.rbs
@@ -1,7 +1,7 @@
 class WS2812
   attr_reader brightness: Integer
 
-  def initialize: (pin: Integer, num: Integer) -> void
+  def initialize: (pin: Integer, num: Integer, ?order: Symbol) -> void
   def set_rgb: (Integer index, Integer r, Integer g, Integer b) -> void
   def set_hsb: (Integer index, Integer h, Integer s, Integer b) -> void
   def set_hex: (Integer index, Integer hex) -> void
@@ -15,6 +15,6 @@ class WS2812
 
   def hsb_to_rgb: (Integer h, Integer s, Integer b) -> [Integer, Integer, Integer]
   def _init: (Integer pin) -> void
-  def _show: (Array[Integer] buffer, Integer brightness) -> void
+  def _show: (Array[Integer] buffer, Integer brightness, Integer color_order) -> void
   def _deinit: () -> void
 end

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -9,7 +9,7 @@
  * Weak stub implementations - overridden by platform-specific ports
  */
 __attribute__((weak)) int WS2812_init(uint8_t pin) { (void)pin; return 0; }
-__attribute__((weak)) void WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness) { (void)rgb_data; (void)num_leds; (void)brightness; }
+__attribute__((weak)) void WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness, uint8_t color_order) { (void)rgb_data; (void)num_leds; (void)brightness; (void)color_order; }
 __attribute__((weak)) void WS2812_deinit(void) {}
 
 /*
@@ -31,14 +31,15 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 /*
- * WS2812._show(buffer, brightness)
- * Send pixels with brightness scaling (RGB order input)
+ * WS2812._show(buffer, brightness, color_order)
+ * Send pixels with brightness scaling and color order
  */
 static void
 c__show(mrbc_vm *vm, mrbc_value *v, int argc)
 {
     mrbc_value data = v[1];
     int brightness = GET_INT_ARG(2);
+    int color_order = GET_INT_ARG(3);
 
     if (mrbc_type(data) != MRBC_TT_ARRAY) {
         mrbc_raise(vm, MRBC_CLASS(ArgumentError), "data must be an Array");
@@ -58,7 +59,7 @@ c__show(mrbc_vm *vm, mrbc_value *v, int argc)
         buf[i] = (uint8_t)mrbc_integer(mrbc_array_get(&data, i));
     }
 
-    WS2812_show(buf, num_leds, (uint8_t)brightness);
+    WS2812_show(buf, num_leds, (uint8_t)brightness, (uint8_t)color_order);
 
     mrbc_free(vm, buf);
 


### PR DESCRIPTION
## Summary

Some WS2812-compatible LEDs expect RGB data order instead of the standard GRB. This adds an `order:` option to the constructor to support both.

- `WS2812.new(pin:, num:, order: :grb)` — default is GRB (standard WS2812)
- Use `:rgb` for LEDs that expect RGB order

## Changes

- Add `order:` keyword argument to `initialize` (default `:grb`)
- RP2040/RP2350: Add `color_order` parameter to `WS2812_show()` in C for hardware-level reordering
- ESP32 (RMT): Reorder bytes in Ruby-side `show` based on color order
- Define `WS2812_ORDER_GRB` / `WS2812_ORDER_RGB` constants in header
- Update README and RBS type signatures