### PR TITLE
Add ESP32 port and simplify platform abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,28 @@ A WS2812 LED driver gem for PicoRuby. Supports ESP32 (using RMT peripheral) and 
 
 ### ESP32
 
-Add the following line to your `picoruby/build_config/xtensa-esp.rb`:
+1. Add the following line to your `picoruby/build_config/xtensa-esp.rb`:
 
-```ruby
-conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'main'
-```
+   ```ruby
+   conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'main'
+   ```
+
+2. Add the following lines to your ESP32 component's `CMakeLists.txt`:
+
+   ```diff
+    idf_component_register(
+      SRCS
+        ...
+        ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-rmt/ports/esp32/rmt.c
+   +    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-ws2812/ports/esp32/ws2812.c
+        ...
+      INCLUDE_DIRS
+        ...
+   +    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-ws2812/include
+   +    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-rmt/include
+        ...
+    )
+   ```
 
 ### RP2040/RP2350 (R2P2)
 

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -1,9 +1,3 @@
-# Try to load RMT for ESP32 (ignore if not available on RP2040/RP2350)
-begin
-  require 'rmt'
-rescue LoadError
-end
-
 class WS2812
   attr_reader :brightness
 
@@ -12,20 +6,7 @@ class WS2812
     @brightness = 100
     @buffer = Array.new(num * 3, 0)
     @order = order
-
-    # ESP32: use RMT directly, RP2040/RP2350: use C bindings
-    begin
-      @rmt = RMT.new(pin,
-        t0h_ns: 350,
-        t0l_ns: 800,
-        t1h_ns: 700,
-        t1l_ns: 600,
-        reset_ns: 60000
-      )
-    rescue NameError
-      # RMT not available, use C bindings (RP2040/RP2350)
-      _init(pin)
-    end
+    _init(pin)
   end
 
   def set_rgb(index, r, g, b)
@@ -56,25 +37,7 @@ class WS2812
   end
 
   def show
-    if @rmt
-      # ESP32: keep Ruby implementation for RMT
-      bytes = []
-      scale = @brightness / 100.0
-      @num_leds.times do |i|
-        r = (@buffer[i * 3] * scale).to_i
-        g = (@buffer[i * 3 + 1] * scale).to_i
-        b = (@buffer[i * 3 + 2] * scale).to_i
-        if @order == :rgb
-          bytes << r << g << b
-        else
-          bytes << g << r << b
-        end
-      end
-      @rmt.write(bytes)
-    else
-      # RP2040/RP2350: use optimized C implementation
-      _show(@buffer, @brightness, @order == :rgb ? 1 : 0)
-    end
+    _show(@buffer, @brightness, @order == :rgb ? 1 : 0)
   end
 
   def clear
@@ -83,12 +46,7 @@ class WS2812
   end
 
   def close
-    if @rmt
-      @rmt.close if @rmt.respond_to?(:close)
-      @rmt = nil
-    else
-      _deinit
-    end
+    _deinit
   end
 
   private

--- a/ports/esp32/ws2812.c
+++ b/ports/esp32/ws2812.c
@@ -1,0 +1,66 @@
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "rmt.h"
+#include "../../include/ws2812.h"
+
+static bool initialized = false;
+
+int
+WS2812_init(uint8_t pin)
+{
+    if (initialized) {
+        return 0;  /* Already initialized */
+    }
+
+    RMT_symbol_dulation_t timing = {
+        .t0h_ns   = 350,
+        .t0l_ns   = 800,
+        .t1h_ns   = 700,
+        .t1l_ns   = 600,
+        .reset_ns = 60000
+    };
+
+    int ret = RMT_init((uint32_t)pin, &timing);
+    if (ret == 0) {
+        initialized = true;
+    }
+    return ret;
+}
+
+void
+WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness, uint8_t color_order)
+{
+    if (!initialized) return;
+
+    int nbytes = num_leds * 3;
+    uint8_t *buf = (uint8_t *)malloc(nbytes);
+    if (!buf) return;
+
+    for (int i = 0; i < num_leds; i++) {
+        /* Apply brightness scaling with integer math */
+        uint8_t r = (rgb_data[i * 3]     * brightness) / 100;
+        uint8_t g = (rgb_data[i * 3 + 1] * brightness) / 100;
+        uint8_t b = (rgb_data[i * 3 + 2] * brightness) / 100;
+
+        if (color_order == WS2812_ORDER_RGB) {
+            buf[i * 3]     = r;
+            buf[i * 3 + 1] = g;
+            buf[i * 3 + 2] = b;
+        } else {  /* GRB (default) */
+            buf[i * 3]     = g;
+            buf[i * 3 + 1] = r;
+            buf[i * 3 + 2] = b;
+        }
+    }
+
+    RMT_write(buf, (uint32_t)nbytes);
+
+    free(buf);
+}
+
+void
+WS2812_deinit(void)
+{
+    initialized = false;
+}

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -6,13 +6,6 @@
 #include "../include/ws2812.h"
 
 /*
- * Weak stub implementations - overridden by platform-specific ports
- */
-__attribute__((weak)) int WS2812_init(uint8_t pin) { (void)pin; return 0; }
-__attribute__((weak)) void WS2812_show(const uint8_t *rgb_data, int num_leds, uint8_t brightness, uint8_t color_order) { (void)rgb_data; (void)num_leds; (void)brightness; (void)color_order; }
-__attribute__((weak)) void WS2812_deinit(void) {}
-
-/*
  * WS2812._init(pin)
  * Initialize WS2812 PIO driver on specified GPIO pin
  */


### PR DESCRIPTION
Summary

  - Add ESP32 port implementation using RMT peripheral (ports/esp32/ws2812.c)
  - Remove weak symbol stubs from src/ws2812.c — follow the standard PicoRuby gem pattern where each port
  provides its own implementation and the header declares the interface
  - Simplify Ruby layer by removing platform branching logic (RMT fallback in Ruby) — all platforms now use the
  same C binding path (_init, _show, _deinit)
  - Update mrbgem.rake to only declare dependency, without manually adding object files or include paths
  - Update README with ESP32 CMakeLists.txt setup instructions

  Background

  The previous approach used __attribute__((weak)) stubs in src/ws2812.c, but these could prevent the linker
  from extracting strong symbols from port object files when both are in static libraries. Removing weak stubs
  and following the standard PicoRuby pattern (header declaration + port implementation) resolves this.

  Note

  The ESP32 port requires adding source and include paths to the ESP32 project's CMakeLists.txt — this is
  consistent with how other PicoRuby gems handle ESP32 builds.