### PR TITLE
Set default brightness to 5% for USB power safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ WS2812.new(pin:, num:, order: :grb)
 | `set_hsb(index, h, s, b)` | Set LED color using HSB (H: 0-360, S: 0-100, B: 0-100) |
 | `fill(r, g, b)` | Fill all LEDs with the same RGB color |
 | `brightness` | Get current brightness (0-100) |
-| `brightness=` | Set brightness (0-100) |
+| `brightness=` | Set brightness (0-100, default: 5) |
 | `show` | Send buffer to LEDs |
 | `clear` | Turn off all LEDs (fills buffer with 0 and calls show) |
 | `close` | Release driver resources |
@@ -93,6 +93,7 @@ WS2812.new(pin:, num:, order: :grb)
 - Out-of-range index values are silently ignored
 - RGB values are masked to 0-255
 - Brightness is applied at `show` time (buffer values are not modified)
+- Default brightness is 5 (5%) for safety — running many LEDs at full brightness draws significant current and can exceed USB power limits
 
 ## Examples
 

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -8,7 +8,7 @@ class WS2812
 
   def initialize(pin:, num:, order: :grb)
     @num_leds = num
-    @brightness = 100
+    @brightness = 5
     @buffer = Array.new(num * 3, 0)
     @order = order
     @rmt = nil


### PR DESCRIPTION
- Set default brightness from 100 to 5 (5%) to prevent exceeding USB power supply limits when driving many LEDs
- Document default brightness value in README