### PR TITLE
Refactor _convert to use instance variables directly

### DIFF
--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -13,6 +13,7 @@ class WS2812
     @order = order
     @rmt = nil
     @sm = nil
+    @pixel_packed = 0
 
     begin
       @rmt = RMT.new(pin,
@@ -23,6 +24,7 @@ class WS2812
         reset_ns: 60000
       )
     rescue NameError
+      @pixel_packed = 1
       _init_pio(pin)
     end
   end
@@ -56,9 +58,9 @@ class WS2812
 
   def show
     if @rmt
-      @rmt.write(_convert(@buffer, @brightness, @order == :rgb ? 1 : 0))
+      @rmt.write(_convert)
     else
-      _convert(@buffer, @brightness, @order == :rgb ? 1 : 0, 1).each do |pixel|
+      _convert.each do |pixel|
         @sm.put(pixel)
       end
     end

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -25,7 +25,7 @@ class WS2812
       )
     rescue NameError
       @pixel_packed = 1
-      _init_pio(pin)
+      init_pio(pin)
     end
   end
 
@@ -79,8 +79,8 @@ class WS2812
 
   private
 
-  def _init_pio(pin)
-    program = self.class._pio_program
+  def init_pio(pin)
+    program = self.class.pio_program
     @sm = PIO::StateMachine.new(
       pio: PIO::PIO0,
       sm: 0,
@@ -95,7 +95,7 @@ class WS2812
     @sm.start
   end
 
-  def self._pio_program
+  def self.pio_program
     return WS2812_PIO_PROGRAM if WS2812_PIO_PROGRAM
 
     PIO.asm(side_set: 1) do

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -14,13 +14,7 @@ class WS2812
     @pixel_packed = 0
 
     begin
-      @rmt = RMT.new(pin,
-        t0h_ns: 350,
-        t0l_ns: 800,
-        t1h_ns: 700,
-        t1l_ns: 600,
-        reset_ns: 60000
-      )
+      init_rmt(pin)
     rescue NameError
       @pixel_packed = 1
       init_pio(pin)
@@ -76,6 +70,16 @@ class WS2812
   end
 
   private
+
+  def init_rmt(pin)
+    @rmt = RMT.new(pin,
+      t0h_ns: 350,
+      t0l_ns: 800,
+      t1h_ns: 700,
+      t1l_ns: 600,
+      reset_ns: 60000
+    )
+  end
 
   def init_pio(pin)
     program = self.class.pio_program

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -5,7 +5,7 @@ class WS2812
   attr_reader :brightness
 
   def initialize(pin:, num:, order: :grb)
-    @num_leds = num
+    @num = num
     @brightness = 5
     @buffer = Array.new(num * 3, 0)
     @order = order
@@ -22,7 +22,7 @@ class WS2812
   end
 
   def set_rgb(index, r, g, b)
-    return if index < 0 || index >= @num_leds
+    return if index < 0 || index >= @num
     @buffer[index * 3]     = r & 0xFF
     @buffer[index * 3 + 1] = g & 0xFF
     @buffer[index * 3 + 2] = b & 0xFF
@@ -41,7 +41,7 @@ class WS2812
   end
 
   def fill(r, g, b)
-    @num_leds.times { |i| set_rgb(i, r, g, b) }
+    @num.times { |i| set_rgb(i, r, g, b) }
   end
 
   def brightness=(val)

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -2,8 +2,6 @@ begin; require 'rmt'; rescue LoadError; end
 begin; require 'pio'; rescue LoadError; end
 
 class WS2812
-  WS2812_PIO_PROGRAM = nil
-
   attr_reader :brightness
 
   def initialize(pin:, num:, order: :grb)
@@ -96,8 +94,6 @@ class WS2812
   end
 
   def self.pio_program
-    return WS2812_PIO_PROGRAM if WS2812_PIO_PROGRAM
-
     PIO.asm(side_set: 1) do
       wrap_target
       label :bitloop

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -27,10 +27,9 @@ c__convert(mrbc_vm *vm, mrbc_value *v, int argc)
         return;
     }
 
-    int len = mrbc_array_size(&data);
-    int num_leds = len / 3;
+    int num_leds = mrbc_integer(GETIV(num));
 
-    mrbc_value result = mrbc_array_new(vm, pack32 ? num_leds : len);
+    mrbc_value result = mrbc_array_new(vm, pack32 ? num_leds : num_leds * 3);
 
     for (int i = 0; i < num_leds; i++) {
         uint8_t r = (uint8_t)mrbc_integer(mrbc_array_get(&data, i * 3));

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -5,19 +5,22 @@
 #include <mrubyc.h>
 #include "../include/ws2812.h"
 
+#define GETIV(str) mrbc_instance_getiv(&v[0], mrbc_str_to_symid(#str))
+
 /*
- * WS2812._convert(buffer, brightness, color_order, pack32)
- * Apply brightness scaling and color order conversion
- * pack32 == 0: returns byte Array [c1, c2, c3, ...] (for RMT)
- * pack32 != 0: returns 32-bit packed Array [0xC1C2C300, ...] (for PIO)
+ * WS2812._convert
+ * Apply brightness scaling and color order conversion using instance variables
+ * @pixel_packed == 0: returns byte Array [c1, c2, c3, ...] (for RMT)
+ * @pixel_packed != 0: returns 32-bit packed Array [0xC1C2C300, ...] (for PIO)
  */
 static void
 c__convert(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-    mrbc_value data = v[1];
-    int brightness = GET_INT_ARG(2);
-    int color_order = GET_INT_ARG(3);
-    int pack32 = (argc >= 4) ? GET_INT_ARG(4) : 0;
+    mrbc_value data = GETIV(buffer);
+    int brightness = mrbc_integer(GETIV(brightness));
+    mrbc_sym rgb_sym = mrbc_str_to_symid("rgb");
+    int color_order = (GETIV(order).sym_id == rgb_sym) ? WS2812_ORDER_RGB : WS2812_ORDER_GRB;
+    int pack32 = mrbc_integer(GETIV(pixel_packed));
 
     if (mrbc_type(data) != MRBC_TT_ARRAY) {
         mrbc_raise(vm, MRBC_CLASS(ArgumentError), "data must be an Array");


### PR DESCRIPTION
- Access `@buffer`, `@brightness`, `@order` directly in C via mrbc_instance_getiv() instead of passing as Ruby arguments
- Eliminates Ruby-side `@order == :rgb ? 1 : 0` expression (removes == method dispatch overhead)
- Follows the GETIV macro pattern used in other picoruby gems (adc, uart, i2c, etc.)