### PR TITLE
Fix incomplete PIO output for large LED counts

### DIFF
--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -52,9 +52,7 @@ class WS2812
     if @rmt
       @rmt.write(_convert)
     else
-      _convert.each do |pixel|
-        @sm.put(pixel)
-      end
+      @sm.put_bytes(_convert)
     end
     nil
   end


### PR DESCRIPTION
- Replace .each { |pixel| @sm.put(pixel) } with @sm.put_bytes(_convert) for PIO pixel output
- Eliminates block creation and yield overhead per pixel by using PIO gem's existing while-based put_bytes method
- Fixes intermittent incomplete LED updates with 256 LEDs