### PR TITLE
Optimize loop performance and reduce instance variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,7 @@ For large LED counts or high-framerate animations, see [picoruby-ws2812-plus](ht
 
 ## Installation
 
-Install as a RuntimeGem (no build required):
-
-```ruby
-# On PicoRuby shell
-gem install ws2812
-```
-
-Or add to your build configuration:
+Add the following line to your build configuration:
 
 ```ruby
 conf.gem github: 'ksbmyk/picoruby-ws2812', branch: 'main'

--- a/mrblib/ws2812.rb
+++ b/mrblib/ws2812.rb
@@ -11,12 +11,10 @@ class WS2812
     @order = order
     @rmt = nil
     @sm = nil
-    @pixel_packed = 0
 
     begin
       init_rmt(pin)
     rescue NameError
-      @pixel_packed = 1
       init_pio(pin)
     end
   end
@@ -41,7 +39,11 @@ class WS2812
   end
 
   def fill(r, g, b)
-    @num.times { |i| set_rgb(i, r, g, b) }
+    i = @num
+    while 0 < i
+      i -= 1
+      set_rgb(i, r, g, b)
+    end
   end
 
   def brightness=(val)
@@ -58,7 +60,7 @@ class WS2812
   end
 
   def clear
-    @buffer.size.times { |i| @buffer[i] = 0 }
+    fill(0, 0, 0)
     show
   end
 
@@ -116,10 +118,10 @@ class WS2812
     buf = @buffer
     br = @brightness
     rgb = @order == :rgb
-    pack = @pixel_packed != 0
+    pack = @rmt == nil
     j = 0
-    i = 0
-    while i < @num
+    i = @num
+    while 0 < i
       r = (buf[j]     * br) / 100
       g = (buf[j + 1] * br) / 100
       b = (buf[j + 2] * br) / 100
@@ -136,7 +138,7 @@ class WS2812
         result << c1 << c2 << c3
       end
       j += 3
-      i += 1
+      i -= 1
     end
     result
   end


### PR DESCRIPTION
## Summary                                                                                                                                                                            
                                                                                                                                                                                    
- Optimize hot-path loops for mruby/c VM performance                                                                                                                                  
- Remove `@pixel_packed` instance variable                                                                                                                                            
                                                                                                                                                                                        
## Changes                                                                                                                                                                          
- `fill`: Replace `times` block with `while` loop using countdown
- `clear`: Reuse `fill(0, 0, 0)` instead of `times` block
- `_convert`: Use countdown with zero comparison, derive pack format from `@rmt`
- Remove `@pixel_packed` from `initialize` (replaced by `@rmt == nil` check)